### PR TITLE
Fix codecov CI and update template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,23 +1,23 @@
 {
-  "template": "https://github.com/scverse/cookiecutter-scverse",
-  "commit": "bc7910b9b7e415d718c4b9eb96d4451997dfa8fe",
-  "context": {
-    "cookiecutter": {
-      "project_name": "infercnvpy",
-      "package_name": "infercnvpy",
-      "project_description": "Infer copy number variation (CNV) from scRNA-seq data. Plays nicely with Scanpy. ",
-      "author_full_name": "Gregor Sturm",
-      "author_email": "mail@gregor-sturm.de",
-      "github_user": "grst",
-      "project_repo": "https://github.com/icbi-lab/infercnvpy",
-      "license": "BSD 3-Clause License",
-      "_copy_without_render": [
-        ".github/workflows/**.yaml",
-        "docs/_templates/autosummary/**.rst"
-      ],
-      "_template": "https://github.com/scverse/cookiecutter-scverse"
-    }
-  },
-  "directory": null,
-  "checkout": "main"
+    "template": "https://github.com/scverse/cookiecutter-scverse",
+    "commit": "bc7910b9b7e415d718c4b9eb96d4451997dfa8fe",
+    "context": {
+        "cookiecutter": {
+            "project_name": "infercnvpy",
+            "package_name": "infercnvpy",
+            "project_description": "Infer copy number variation (CNV) from scRNA-seq data. Plays nicely with Scanpy. ",
+            "author_full_name": "Gregor Sturm",
+            "author_email": "mail@gregor-sturm.de",
+            "github_user": "grst",
+            "project_repo": "https://github.com/icbi-lab/infercnvpy",
+            "license": "BSD 3-Clause License",
+            "_copy_without_render": [
+                ".github/workflows/**.yaml",
+                "docs/_templates/autosummary/**.rst"
+            ],
+            "_template": "https://github.com/scverse/cookiecutter-scverse"
+        }
+    },
+    "directory": null,
+    "checkout": "main"
 }

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,23 +1,23 @@
 {
-    "template": "https://github.com/scverse/cookiecutter-scverse",
-    "commit": "57f6267716826dad73baba46dc3c00fe7262c459",
-    "context": {
-        "cookiecutter": {
-            "project_name": "infercnvpy",
-            "package_name": "infercnvpy",
-            "project_description": "Infer copy number variation (CNV) from scRNA-seq data. Plays nicely with Scanpy. ",
-            "author_full_name": "Gregor Sturm",
-            "author_email": "mail@gregor-sturm.de",
-            "github_user": "grst",
-            "project_repo": "https://github.com/icbi-lab/infercnvpy",
-            "license": "BSD 3-Clause License",
-            "_copy_without_render": [
-                ".github/workflows/**.yaml",
-                "docs/_templates/autosummary/**.rst"
-            ],
-            "_template": "https://github.com/scverse/cookiecutter-scverse"
-        }
-    },
-    "directory": null,
-    "checkout": "v0.2.0"
+  "template": "https://github.com/scverse/cookiecutter-scverse",
+  "commit": "bc7910b9b7e415d718c4b9eb96d4451997dfa8fe",
+  "context": {
+    "cookiecutter": {
+      "project_name": "infercnvpy",
+      "package_name": "infercnvpy",
+      "project_description": "Infer copy number variation (CNV) from scRNA-seq data. Plays nicely with Scanpy. ",
+      "author_full_name": "Gregor Sturm",
+      "author_email": "mail@gregor-sturm.de",
+      "github_user": "grst",
+      "project_repo": "https://github.com/icbi-lab/infercnvpy",
+      "license": "BSD 3-Clause License",
+      "_copy_without_render": [
+        ".github/workflows/**.yaml",
+        "docs/_templates/autosummary/**.rst"
+      ],
+      "_template": "https://github.com/scverse/cookiecutter-scverse"
+    }
+  },
+  "directory": null,
+  "checkout": "main"
 }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,15 +6,21 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     package:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python 3.10
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: "3.10"
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
             - name: Install build dependencies
               run: python -m pip install --upgrade pip wheel twine build
             - name: Build package

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -43,4 +43,4 @@ jobs:
                       manually merge these changes.**
 
                       For more information about the template sync, please refer to the
-                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/developer_docs.html#automated-template-sync).
+                      [template documentation](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#automated-template-sync).

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
     pull_request:
         branches: [main]
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     test:
         runs-on: ${{ matrix.os }}
@@ -27,31 +31,24 @@ jobs:
             R_KEEP_PKG_SOURCE: yes
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Set up Python ${{ matrix.python }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python }}
+<<<<<<<
             - uses: r-lib/actions/setup-r@v2
               with:
                   r-version: ${{ matrix.r }}
                   use-public-rspm: true
+=======
+                  cache: "pip"
+                  cache-dependency-path: "**/pyproject.toml"
+>>>>>>>
 
-            - name: Get pip cache dir
-              id: pip-cache-dir
-              run: |
-                  echo "::set-output name=dir::$(pip cache dir)"
-            - name: Restore pip cache
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.pip-cache-dir.outputs.dir }}
-                  key: pip-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml') }}
-                  restore-keys: |
-                      pip-${{ runner.os }}-${{ env.pythonLocation }}-
             - name: Install test dependencies
               run: |
                   python -m pip install --upgrade pip wheel
-                  pip install codecov
             - name: Install dependencies
               run: |
                   pip install ".[dev,test,copykat]"
@@ -71,7 +68,4 @@ jobs:
               run: |
                   pytest -v --cov --color=yes
             - name: Upload coverage
-              env:
-                  CODECOV_NAME: ${{ matrix.python }}-${{ matrix.os }}
-              run: |
-                  codecov --required --flags=unittests
+              uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -74,14 +74,15 @@ For questions and help requests, you can reach out in the [scverse discourse][sc
 If you found a bug, please use the [issue tracker][issue-tracker].
 
 <<<<<<<
+
 ## Citation
 
 n/a
 
 =======
->>>>>>>
-[scverse-discourse]: https://discourse.scverse.org/
-[issue-tracker]: https://github.com/icbi-lab/infercnvpy/issues
-[changelog]: https://infercnvpy.readthedocs.io/latest/changelog.html
-[link-docs]: https://infercnvpy.readthedocs.io
-[link-api]: https://infercnvpy.readthedocs.io/latest/api.html
+
+> > > > > > > [scverse-discourse]: https://discourse.scverse.org/
+> > > > > > > [issue-tracker]: https://github.com/icbi-lab/infercnvpy/issues
+> > > > > > > [changelog]: https://infercnvpy.readthedocs.io/latest/changelog.html
+> > > > > > > [link-docs]: https://infercnvpy.readthedocs.io
+> > > > > > > [link-api]: https://infercnvpy.readthedocs.io/latest/api.html

--- a/README.md.orig
+++ b/README.md.orig
@@ -73,13 +73,10 @@ See the [changelog][changelog].
 For questions and help requests, you can reach out in the [scverse discourse][scverse-discourse].
 If you found a bug, please use the [issue tracker][issue-tracker].
 
-<<<<<<<
 ## Citation
 
 n/a
 
-=======
->>>>>>>
 [scverse-discourse]: https://discourse.scverse.org/
 [issue-tracker]: https://github.com/icbi-lab/infercnvpy/issues
 [changelog]: https://infercnvpy.readthedocs.io/latest/changelog.html

--- a/README.md.rej
+++ b/README.md.rej
@@ -2,7 +2,7 @@ diff a/README.md b/README.md	(rejected hunks)
 @@ -45,10 +45,6 @@ See the [changelog][changelog].
  For questions and help requests, you can reach out in the [scverse discourse][scverse-discourse].
  If you found a bug, please use the [issue tracker][issue-tracker].
- 
+
 -## Citation
 -
 -> t.b.a

--- a/README.md.rej
+++ b/README.md.rej
@@ -1,0 +1,12 @@
+diff a/README.md b/README.md	(rejected hunks)
+@@ -45,10 +45,6 @@ See the [changelog][changelog].
+ For questions and help requests, you can reach out in the [scverse discourse][scverse-discourse].
+ If you found a bug, please use the [issue tracker][issue-tracker].
+ 
+-## Citation
+-
+-> t.b.a
+-
+ [scverse-discourse]: https://discourse.scverse.org/
+ [issue-tracker]: https://github.com/grst/infercnvpy/issues
+ [changelog]: https://infercnvpy.readthedocs.io/latest/changelog.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,12 +16,15 @@ sys.path.insert(0, str(HERE / "extensions"))
 
 # -- Project information -----------------------------------------------------
 
+# NOTE: If you installed your project in editable mode, this might be stale.
+#       If this is the case, reinstall it to refresh the metadata
 info = metadata("infercnvpy")
 project_name = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
-repository_url = f"https://github.com/grst/{project_name}"
+urls = dict(pu.split(", ") for pu in info.get_all("Project-URL"))
+repository_url = urls["Source"]
 
 # The full version, including alpha/beta/rc tags
 release = info["Version"]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -142,6 +142,7 @@ Please write documentation for new or changed features and use-cases. This proje
 -   [Numpy-style docstrings][numpydoc] (through the [napoloen][numpydoc-napoleon] extension).
 -   Jupyter notebooks as tutorials through [myst-nb][] (See [Tutorials with myst-nb](#tutorials-with-myst-nb-and-jupyter-notebooks))
 -   [Sphinx autodoc typehints][], to automatically reference annotated input and output types
+-   Citations (like {cite:p}`Virshup_2023`) can be included with [sphinxcontrib-bibtex](https://sphinxcontrib-bibtex.readthedocs.io/)
 
 See the [scanpy developer docs](https://scanpy.readthedocs.io/en/latest/dev/documentation.html) for more information
 on how to write documentation.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,3 +1,16 @@
+<<<<<<<
+=======
+@article{Virshup_2023,
+	doi = {10.1038/s41587-023-01733-8},
+	url = {https://doi.org/10.1038%2Fs41587-023-01733-8},
+	year = 2023,
+	month = {apr},
+	publisher = {Springer Science and Business Media {LLC}},
+	author = {Isaac Virshup and Danila Bredikhin and Lukas Heumos and Giovanni Palla and Gregor Sturm and Adam Gayoso and Ilia Kats and Mikaela Koutrouli and Philipp Angerer and Volker Bergen and Pierre Boyeau and Maren BÃ¼ttner and Gokcen Eraslan and David Fischer and Max Frank and Justin Hong and Michal Klein and Marius Lange and Romain Lopez and Mohammad Lotfollahi and Malte D. Luecken and Fidel Ramirez and Jeffrey Regier and Sergei Rybakov and Anna C. Schaar and Valeh Valiollah Pour Amiri and Philipp Weiler and Galen Xing and Bonnie Berger and Dana Pe'er and Aviv Regev and Sarah A. Teichmann and Francesca Finotello and F. Alexander Wolf and Nir Yosef and Oliver Stegle and Fabian J. Theis and},
+	title = {The scverse project provides a computational ecosystem for single-cell omics data analysis},
+	journal = {Nature Biotechnology}
+}
+>>>>>>>
 @article{Maynard2020,
   doi       = {10.1016/j.cell.2020.07.017},
   url       = {https://doi.org/10.1016/j.cell.2020.07.017},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,9 @@ ignore = [
     "D213",
 ]
 
+[tool.ruff.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.per-file-ignores]
 "docs/*" = ["I"]
 "tests/*" = ["D"]


### PR DESCRIPTION
This PR fixes some problems with the CI setup of the scverse-cookiecutter template repo. Last night, [the `codecov` package was pulled from PyPI](https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259). This can easily be replaced, however we've realized our automatic template sync system does not allow us to modify github actions (a security precaution from github), so we need to roll out this update manually.

We're also taking this opportunity to make several other intended changes for to the CI workflow.

We're still looking into how we can avoid this in the future, which will likely require us changing how our template sync system works. This is being tracked in the [scverse/cookiecutter-scverse#138](https://github.com/scverse/cookiecutter-scverse/issues/138). 

## Changes

These changes constitute the 0.2.1 release of the template and make the following changes:

* Remove codecov as a dependency since it's been pulled from pypi (scverse/cookiecutter-scverse#161)
* Remove usage of deprecated GitHub actions environment variables (these will be removed in a month) (scverse/cookiecutter-scverse#161)
* Fix some spurious ruff errors ( scverse/cookiecutter-scverse#156, scverse/cookiecutter-scverse#159 )
* Replace the example citation with the scverse manuscript ( scverse/cookiecutter-scverse#160 )
* automatically cancel running CI jobs on new commit (scverse/cookiecutter-scverse#158)

## Additional remarks
* If there are **merge conflicts** a `.rej` file will have been created for the respective files. You need to address these conflicts manually. Make sure to enable pre-commit.ci (see below) to detect such files.
* The scverse template works best when the [pre-commit.ci](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#pre-commit-ci), [readthedocs](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#documentation-on-readthedocs) and [codecov](https://cookiecutter-scverse-instance.readthedocs.io/en/latest/template_usage.html#coverage-tests-with-codecov) services are enabled. Make sure to activate those apps if you haven't already. 
